### PR TITLE
Build fixes for Ubuntu 14.04 & current Plastic

### DIFF
--- a/plastic/Dockerfile
+++ b/plastic/Dockerfile
@@ -1,20 +1,20 @@
-FROM ubuntu:trusty
+﻿FROM ubuntu:trusty
 
 MAINTAINER Miguel González <mgonzalez@codicefactory.com>
 
 RUN apt-get update
-RUN apt-get install -y wget
+RUN apt-get install -y wget apt-transport-https
 
 RUN mkdir /conf
 RUN mkdir /logs
 RUN mkdir -p /db/sqlite
 
-RUN echo "deb http://www.plasticscm.com/plasticrepo/5.0/Ubuntu_14.04/ ./" >> /etc/apt/sources.list.d/plastic.list
-RUN echo "deb http://www.plasticscm.com/plasticrepo/5.4/Ubuntu_14.04/ ./" >> /etc/apt/sources.list.d/plastic.list
-RUN wget -q http://www.plasticscm.com/plasticrepo/5.0/Ubuntu_14.04/Release.key -O - | apt-key add -
-RUN wget -q http://www.plasticscm.com/plasticrepo/5.4/Ubuntu_14.04/Release.key -O - | apt-key add -
+RUN echo "deb http://www.plasticscm.com/plasticrepo/plasticscm-common/Ubuntu_14.04/ ./" > /etc/apt/sources.list.d/plastic.list
+RUN echo "deb http://www.plasticscm.com/plasticrepo/plasticscm-latest/Ubuntu_14.04/ ./" >> /etc/apt/sources.list.d/plastic.list
+RUN wget -q http://www.plasticscm.com/plasticrepo/plasticscm-common/Ubuntu_14.04/Release.key -O - | apt-key add -
+RUN wget -q http://www.plasticscm.com/plasticrepo/plasticscm-latest/Ubuntu_14.04/Release.key -O - | apt-key add -
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -q update && apt-get install -y -q plasticscm-client plasticscm-server && plasticsd stop
+RUN DEBIAN_FRONTEND=noninteractive apt-get -q update && apt-get install -y -q plasticscm-complete && plasticsd stop
 
 RUN { \
     clconfigureserver --language=en --port=8087 --workingmode=UPWorkingMode; \


### PR DESCRIPTION
* Need to install HTTPS transport for APT, since plasticscm.com repos are redirected to serve over HTTPS
* APT repo paths for Plastic files have changed
* plastic package name has changed

With these changes I can successfully build an image locally.