### PR TITLE
Create default client configuration for "root" user

### DIFF
--- a/plastic/Dockerfile
+++ b/plastic/Dockerfile
@@ -24,6 +24,7 @@ RUN { \
     ln -s /conf/users.conf /opt/plasticscm5/server && ln -s /conf/groups.conf /opt/plasticscm5/server; \
     ln -s /conf/plasticd.lic /opt/plasticscm5/server; \
     ln -s /conf/plasticd.token.lic /opt/plasticscm5/server; \
+    ln -s /conf/client.conf /opt/plasticscm5/client/client.conf; \
 }
 
 RUN umtool cu root root
@@ -32,6 +33,7 @@ RUN umtool autg root administrators
 
 ADD loader.log.conf /opt/plasticscm5/server/
 ADD db.conf /opt/plasticscm5/server/
+ADD client.conf /conf
 
 EXPOSE 8087
 

--- a/plastic/client.conf
+++ b/plastic/client.conf
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<ClientConfigData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Language>en</Language>
+  <WorkspaceServer>localhost:8087</WorkspaceServer>
+  <WorkingMode>UPWorkingMode</WorkingMode>
+  <SecurityConfig>root:umPo5U0yaxGGpa4PnRXkOg==</SecurityConfig>
+  <MergeTools>
+    <MergeToolData>
+      <FileType>enTextFile</FileType>
+      <FileExtensions>*</FileExtensions>
+      <Tools>
+        <string>gtkmergetool -b="@basefile" -bn="@basesymbolic" -bh="@basehash" -s="@sourcefile" -sn="@sourcesymbolic" -sh="@sourcehash" -d="@destinationfile" -dh="@destinationhash" -a -r="@output" -t="@filetype" -i="@comparationmethod" -e="@fileencoding" -m="@mergetype" -re="@resultencoding" --progress="@progress" --extrainfofile="@extrainfofile"</string>
+      </Tools>
+    </MergeToolData>
+  </MergeTools>
+  <DiffTools>
+    <DiffToolData>
+      <FileType>enTextFile</FileType>
+      <FileExtensions>*</FileExtensions>
+      <Tools>
+        <string>gtkmergetool -s="@sourcefile" -sn="@sourcesymbolic" -d="@destinationfile" -dn="@destinationsymbolic" -t="@filetype" -i="@comparationmethod" -e="@fileencoding"</string>
+      </Tools>
+    </DiffToolData>
+  </DiffTools>
+  <SetFilesAsReadOnly>no</SetFilesAsReadOnly>
+  <SetRevisionFileDate>no</SetRevisionFileDate>
+  <SupportSmbWorkspaces>no</SupportSmbWorkspaces>
+  <PerformAddPlusCi>no</PerformAddPlusCi>
+  <CheckFileContentForChanged>no</CheckFileContentForChanged>
+  <CaseSensitiveFsOnMac>no</CaseSensitiveFsOnMac>
+  <SameItemDifferentCaseError>no</SameItemDifferentCaseError>
+  <CheckinQueuesSize>50</CheckinQueuesSize>
+  <DownloadPoolSize>1</DownloadPoolSize>
+  <UploadCompressionSize>1</UploadCompressionSize>
+  <LastRunningEdition>team_or_enterprise</LastRunningEdition>
+</ClientConfigData>


### PR DESCRIPTION
This allows you to log directly into the container, and use "cm" commands against the server. For example, "cm lrep" will work without any further configuration required.

The "clconfigureclient" command should ideally have been used to do this instead of providing a pre-made client.conf file, but the command does not support specifying username/password on the command line.